### PR TITLE
Add Flask 3 migration scaffolding

### DIFF
--- a/docs/MIGRATION_FLASK3.md
+++ b/docs/MIGRATION_FLASK3.md
@@ -1,0 +1,50 @@
+# Flask 3.x Migration Strategy
+
+This document outlines the approach for migrating PowerDNS-Admin from Flask 2.2 to Flask 3.x.
+
+## Compatibility Assessment
+
+- **Import changes**: `flask.ext.*` imports have long been removed. Extensions should be imported directly (e.g. `from flask_mail import Mail`).
+- **Blueprint registration**: Ensure `blueprint.name` is unique and use `app.register_blueprint` with explicit URL prefixes.
+- **Request context**: Use `request.get_json()` and `flask.current_app` access patterns.
+- **JSON handling**: Switch to `flask.json` provider API where available.
+- **Templates**: Jinja2 3 is still supported; ensure custom filters are registered via `app.jinja_env.filters`.
+- **Extension compatibility**: See table below.
+
+| Extension | Current Version | Flask 3 Compatible |
+|-----------|-----------------|--------------------|
+| Flask-SQLAlchemy | 2.5.1 | Use >=3.1 |
+| Flask-Login | 0.6.2 | Compatible |
+| Flask-Mail | 0.9.1 | Use >=0.9.1 with Flask 3 patches |
+| Flask-Migrate | 2.5.3 | Use >=4.0 |
+| Flask-Assets | 2.0 | Consider replacement (e.g. Flask-Webpack) |
+| Flask-Session | 0.4.0 | Compatible |
+
+## Phased Migration
+
+1. **Compatibility Layer**: added under `powerdnsadmin/compat/` providing helpers abstracting Flask 2/3 differences.
+2. **Core Migration**: new `powerdnsadmin/core/` package introducing a modern app factory and blueprint registry.
+3. **Extension Updates**: upgrade extensions to Flask 3 compatible versions and wrap legacy APIs in `extension_compat`.
+
+## API Stability
+
+- Decorate endpoints with version-aware decorators.
+- Validate request and response formats.
+- Emit warnings for deprecated behaviour.
+- Expand the test suite to cover API contracts.
+
+## Configuration Management
+
+- Support environment driven configuration with typed classes.
+- Validate configuration on startup and integrate secret management.
+
+## Testing Strategy
+
+- Execute tests against Flask 2 and Flask 3 in CI.
+- Include performance benchmarking and rollback tests.
+
+## Deployment and Rollback
+
+1. Deploy compatibility layer alongside existing code.
+2. Roll forward by enabling Flask 3 in a staging environment.
+3. Rollback simply involves reverting to the previous Docker image and database state.

--- a/powerdnsadmin/compat/extension_compat.py
+++ b/powerdnsadmin/compat/extension_compat.py
@@ -1,0 +1,11 @@
+"""Wrappers for Flask extension compatibility."""
+
+from __future__ import annotations
+
+try:
+    from flask_mail import Mail
+except Exception:  # pragma: no cover
+    Mail = object  # type: ignore
+
+
+__all__ = ["Mail"]

--- a/powerdnsadmin/compat/flask_compat.py
+++ b/powerdnsadmin/compat/flask_compat.py
@@ -1,0 +1,23 @@
+"""Compatibility helpers for Flask 2.x and 3.x."""
+
+from __future__ import annotations
+
+import flask
+
+
+try:
+    from flask import json
+except ImportError:  # pragma: no cover - Flask <3.0
+    import json  # type: ignore
+
+
+# Unified json dumps/loads
+if hasattr(flask, "json"):
+    dumps = flask.json.dumps
+    loads = flask.json.loads
+else:  # pragma: no cover - Flask <3.0
+    dumps = json.dumps
+    loads = json.loads
+
+
+__all__ = ["dumps", "loads"]

--- a/powerdnsadmin/compat/request_compat.py
+++ b/powerdnsadmin/compat/request_compat.py
@@ -1,0 +1,21 @@
+"""Request handling helpers to abstract Flask breaking changes."""
+
+from __future__ import annotations
+
+from flask import request
+
+
+def get_json(silent: bool = False):
+    """Return JSON payload in a Flask 2.x/3.x agnostic way."""
+    if hasattr(request, "get_json"):
+        return request.get_json(silent=silent)
+    # Fallback for very old Flask
+    try:
+        return request.json
+    except Exception:  # pragma: no cover
+        if silent:
+            return None
+        raise
+
+
+__all__ = ["get_json"]

--- a/powerdnsadmin/core/__init__.py
+++ b/powerdnsadmin/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core application package for Flask 3 migration."""

--- a/powerdnsadmin/core/app_factory.py
+++ b/powerdnsadmin/core/app_factory.py
@@ -1,0 +1,17 @@
+"""Modern app factory leveraging compatibility layer."""
+
+from __future__ import annotations
+
+from flask import Flask
+from powerdnsadmin.compat.extension_compat import Mail
+
+
+def create_app(config_object: str | None = None) -> Flask:
+    app = Flask(__name__)
+    if config_object:
+        app.config.from_object(config_object)
+
+    # Initialize extensions through compatibility wrappers
+    Mail(app)
+
+    return app

--- a/powerdnsadmin/core/blueprint_registry.py
+++ b/powerdnsadmin/core/blueprint_registry.py
@@ -1,0 +1,15 @@
+"""Blueprint registration utilities."""
+
+from __future__ import annotations
+
+from flask import Flask
+
+
+class BlueprintRegistry:
+    def __init__(self, app: Flask):
+        self.app = app
+        self.blueprints = []
+
+    def register(self, blueprint, url_prefix: str | None = None) -> None:
+        self.app.register_blueprint(blueprint, url_prefix=url_prefix)
+        self.blueprints.append(blueprint)

--- a/powerdnsadmin/core/middleware.py
+++ b/powerdnsadmin/core/middleware.py
@@ -1,0 +1,11 @@
+"""Middleware stack for the Flask 3 application."""
+
+from __future__ import annotations
+
+from flask import Flask
+
+
+def apply_middleware(app: Flask) -> None:
+    """Attach middlewares to the app."""
+    # Placeholders for future middleware e.g. security headers
+    pass

--- a/tests/compat/test_flask_compat.py
+++ b/tests/compat/test_flask_compat.py
@@ -1,0 +1,6 @@
+from powerdnsadmin.compat import flask_compat
+
+def test_json_roundtrip():
+    payload = {"a": 1}
+    dumped = flask_compat.dumps(payload)
+    assert flask_compat.loads(dumped) == payload


### PR DESCRIPTION
## Summary
- lay groundwork for Flask 3 migration
- add compatibility helpers and core scaffolding
- document migration plan
- add basic test for compatibility layer

## Testing
- `pytest -q tests/compat/test_flask_compat.py` *(fails: ModuleNotFoundError: No module named 'flask_migrate')*

------
https://chatgpt.com/codex/tasks/task_e_687a3abf630083339cafd0169e7d733c