### PR TITLE
Add security framework skeleton

### DIFF
--- a/powerdnsadmin/models/user.py
+++ b/powerdnsadmin/models/user.py
@@ -105,7 +105,9 @@ class User(db.Model):
             return plain_text_password
 
         pw = plain_text_password if plain_text_password else self.plain_text_password
-        return bcrypt.hashpw(pw.encode('utf-8'), bcrypt.gensalt())
+        # use explicit rounds to enforce strong hashing cost
+        hashed = bcrypt.hashpw(pw.encode('utf-8'), bcrypt.gensalt(rounds=12))
+        return hashed
 
     def check_password(self, hashed_password):
         # Check hashed password. Using bcrypt, the salt is saved into the hash itself

--- a/powerdnsadmin/security/__init__.py
+++ b/powerdnsadmin/security/__init__.py
@@ -1,0 +1,1 @@
+"""Security utilities for PowerDNS-Admin."""

--- a/powerdnsadmin/security/audit.py
+++ b/powerdnsadmin/security/audit.py
@@ -1,0 +1,7 @@
+"""Dependency vulnerability scanning using pip-audit."""
+from subprocess import run, PIPE
+
+def run_audit(requirements_file: str = "requirements.txt") -> str:
+    """Run pip-audit on the provided requirements file and return the report."""
+    result = run(["pip-audit", "-r", requirements_file], stdout=PIPE, stderr=PIPE, text=True)
+    return result.stdout + result.stderr

--- a/powerdnsadmin/security/compliance.py
+++ b/powerdnsadmin/security/compliance.py
@@ -1,0 +1,14 @@
+"""Security compliance checking utilities."""
+
+from datetime import datetime
+
+
+def check_password_policy(password: str, min_length: int = 12) -> bool:
+    """Simple password policy enforcement."""
+    return len(password) >= min_length
+
+
+def log_compliance_event(event: str) -> None:
+    """Log a compliance event with timestamp."""
+    with open("compliance.log", "a") as fh:
+        fh.write(f"{datetime.utcnow().isoformat()} {event}\n")

--- a/powerdnsadmin/security/encryption.py
+++ b/powerdnsadmin/security/encryption.py
@@ -1,0 +1,31 @@
+"""AES encryption utilities for sensitive data."""
+
+from Crypto.Cipher import AES
+from Crypto.Random import get_random_bytes
+from base64 import b64encode, b64decode
+
+BLOCK_SIZE = 16
+
+
+def pad(data: bytes) -> bytes:
+    padding_len = BLOCK_SIZE - len(data) % BLOCK_SIZE
+    return data + bytes([padding_len]) * padding_len
+
+
+def unpad(data: bytes) -> bytes:
+    padding_len = data[-1]
+    return data[:-padding_len]
+
+
+def encrypt(plaintext: str, key: bytes) -> str:
+    cipher = AES.new(key, AES.MODE_CBC)
+    ct_bytes = cipher.encrypt(pad(plaintext.encode()))
+    return b64encode(cipher.iv + ct_bytes).decode()
+
+
+def decrypt(ciphertext: str, key: bytes) -> str:
+    raw = b64decode(ciphertext)
+    iv = raw[:BLOCK_SIZE]
+    ct = raw[BLOCK_SIZE:]
+    cipher = AES.new(key, AES.MODE_CBC, iv=iv)
+    return unpad(cipher.decrypt(ct)).decode()

--- a/powerdnsadmin/security/incident_response.py
+++ b/powerdnsadmin/security/incident_response.py
@@ -1,0 +1,9 @@
+"""Security incident response stubs."""
+
+from datetime import datetime
+
+
+def create_incident_report(summary: str) -> str:
+    """Create a simple incident report entry."""
+    timestamp = datetime.utcnow().isoformat()
+    return f"{timestamp}: {summary}"

--- a/powerdnsadmin/security/monitoring.py
+++ b/powerdnsadmin/security/monitoring.py
@@ -1,0 +1,10 @@
+"""Runtime security monitoring stubs."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def log_security_event(event: str) -> None:
+    """Log a security event."""
+    logger.info("SECURITY EVENT: %s", event)

--- a/powerdnsadmin/security/token.py
+++ b/powerdnsadmin/security/token.py
@@ -1,0 +1,8 @@
+"""Session and API token utilities."""
+
+import secrets
+
+
+def generate_token(length: int = 32) -> str:
+    """Return a secure random URL-safe token."""
+    return secrets.token_urlsafe(length)

--- a/powerdnsadmin/validators/__init__.py
+++ b/powerdnsadmin/validators/__init__.py
@@ -1,0 +1,1 @@
+"""Input validation utilities."""

--- a/powerdnsadmin/validators/api_validators.py
+++ b/powerdnsadmin/validators/api_validators.py
@@ -1,0 +1,7 @@
+"""API input validation."""
+
+from .security_validators import enforce_request_size
+
+
+def validate_api_key(key: str) -> bool:
+    return len(key) >= 32

--- a/powerdnsadmin/validators/domain_validators.py
+++ b/powerdnsadmin/validators/domain_validators.py
@@ -1,0 +1,9 @@
+"""DNS-specific validation helpers."""
+
+import re
+
+DOMAIN_RE = re.compile(r"^(?:[a-zA-Z0-9-]{,63}\.)+[a-zA-Z]{2,}$")
+
+
+def is_valid_domain(name: str) -> bool:
+    return bool(DOMAIN_RE.match(name))

--- a/powerdnsadmin/validators/security_validators.py
+++ b/powerdnsadmin/validators/security_validators.py
@@ -1,0 +1,7 @@
+"""Security-related input validation."""
+
+MAX_REQUEST_SIZE = 1024 * 1024  # 1MB
+
+
+def enforce_request_size(data: bytes) -> bool:
+    return len(data) <= MAX_REQUEST_SIZE

--- a/powerdnsadmin/validators/user_validators.py
+++ b/powerdnsadmin/validators/user_validators.py
@@ -1,0 +1,9 @@
+"""User input validation."""
+
+import re
+
+USERNAME_RE = re.compile(r"^[a-zA-Z0-9_.-]{3,32}$")
+
+
+def is_valid_username(name: str) -> bool:
+    return bool(USERNAME_RE.match(name))

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,5 @@ rcssmin==1.1.1
 zxcvbn==4.4.28
 psycopg2==2.9.5
 setuptools==80.9.0
+pycryptodome==3.20.0
+pip-audit==2.7.2

--- a/tests/security/test_encryption.py
+++ b/tests/security/test_encryption.py
@@ -1,0 +1,15 @@
+import os
+from powerdnsadmin.security import encryption, token
+
+
+def test_encrypt_decrypt():
+    key = os.urandom(16)
+    secret = "sensitive data"
+    enc = encryption.encrypt(secret, key)
+    dec = encryption.decrypt(enc, key)
+    assert dec == secret
+
+
+def test_generate_token_length():
+    tok = token.generate_token(16)
+    assert len(tok) >= 16


### PR DESCRIPTION
## Summary
- add skeleton modules for security auditing, compliance, monitoring and incident response
- introduce validators for domains, API keys, and user input
- add AES encryption helpers and token generation utilities
- enforce bcrypt rounds in user password hashing
- include a minimal security test for encryption utilities
- add pycryptodome and pip-audit to requirements

## Testing
- `pytest tests/security/test_encryption.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687a3ae72dfc8333ace6f941a3afd71f